### PR TITLE
Fix sync.Mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ func main() {
 		Cache:      autocert.DirCache("/var/www/.cache"),
 	}
 
-	log.Fatal(autotls.RunWithManager(r, m))
+	log.Fatal(autotls.RunWithManager(r, &m))
 }
 ```

--- a/autotls.go
+++ b/autotls.go
@@ -13,7 +13,7 @@ func Run(r http.Handler, domain ...string) error {
 }
 
 // RunWithManager support custom autocert manager
-func RunWithManager(r http.Handler, m autocert.Manager) error {
+func RunWithManager(r http.Handler, m *autocert.Manager) error {
 	s := &http.Server{
 		Addr:      ":https",
 		TLSConfig: &tls.Config{GetCertificate: m.GetCertificate},

--- a/example/example2.go
+++ b/example/example2.go
@@ -22,5 +22,5 @@ func main() {
 		Cache:      autocert.DirCache("/var/www/.cache"),
 	}
 
-	log.Fatal(autotls.RunWithManager(r, m))
+	log.Fatal(autotls.RunWithManager(r, &m))
 }


### PR DESCRIPTION
I'm getting an error ```autotls.RunWithManager copies lock value: golang.org/x/crypto/acme/autocert.Manager contains sync.Mutex ```  if i try to call RunWithManager. 

After some consulting in #go-nuts - i build this patch.