### PR TITLE
Update doc link to reference pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/gin-gonic/autotls.svg?branch=master)](https://travis-ci.org/gin-gonic/autotls) 
 [![Go Report Card](https://goreportcard.com/badge/github.com/gin-gonic/autotls)](https://goreportcard.com/report/github.com/gin-gonic/autotls)
-[![GoDoc](https://godoc.org/github.com/gin-gonic/autotls?status.svg)](https://godoc.org/github.com/gin-gonic/autotls)
+[![GoDoc](https://pkg.go.dev/badge/github.com/gin-gonic/autotls?status.svg)](https://pkg.go.dev/github.com/gin-gonic/autotls)
 [![Join the chat at https://gitter.im/gin-gonic/autotls](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/gin-gonic/autotls?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Support Let's Encrypt for a Go server application.


### PR DESCRIPTION
`godoc.org` is still alive, but requests redirect to pkg.go.dev.
This fixed to point to pkg.go.dev direct to reduce unneeded redirect.

Ref: https://blog.golang.org/godoc.org-redirect