### PR TITLE
Add http redirection to Run function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 
 vendor/*
 !vendor/vendor.json
+.idea

--- a/autocertcache.go
+++ b/autocertcache.go
@@ -1,0 +1,47 @@
+package autotls
+
+import (
+	"errors"
+	"golang.org/x/crypto/acme/autocert"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+func getCacheDir() (autocert.DirCache, error) {
+	dir := cacheDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", errors.New("warning: autocert.NewListener not using a cache: " + err.Error())
+	}
+	return autocert.DirCache(dir), nil
+}
+
+func cacheDir() string {
+	const base = "golang-autocert"
+	switch runtime.GOOS {
+	case "darwin":
+		return filepath.Join(homeDir(), "Library", "Caches", base)
+	case "windows":
+		for _, ev := range []string{"APPDATA", "CSIDL_APPDATA", "TEMP", "TMP"} {
+			if v := os.Getenv(ev); v != "" {
+				return filepath.Join(v, base)
+			}
+		}
+		// Worst case:
+		return filepath.Join(homeDir(), base)
+	}
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, base)
+	}
+	return filepath.Join(homeDir(), ".cache", base)
+}
+
+func homeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+	}
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return "/"
+}

--- a/autotls.go
+++ b/autotls.go
@@ -8,6 +8,7 @@ import (
 
 // Run support 1-line LetsEncrypt HTTPS servers
 func Run(r http.Handler, domain ...string) error {
+	go http.ListenAndServe(":http", http.HandlerFunc(redirect))
 	return http.Serve(autocert.NewListener(domain...), r)
 }
 


### PR DESCRIPTION
I've noticed that **RunWithManager()** permits to redirect a HTTP request to HTTPS, but **Run()** doesn't handle it.