### PR TITLE
chore(deps): upgrade golang.org/x/crypto to v0.55.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/gin-gonic/autotls
 go 1.25.0
 
 require (
-	golang.org/x/crypto v0.54.0
+	golang.org/x/crypto v0.55.0
 	golang.org/x/sync v0.22.0
 )
 
 require (
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/text v0.40.0 // indirect
+	golang.org/x/text v0.41.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
+golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=
 golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
+golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
+golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=


### PR DESCRIPTION
## Summary

The daily **Trivy Security Scan** workflow on the default branch has been failing because `golang.org/x/crypto` v0.54.0 is affected by CVE-2026-56854 (CRITICAL, `golang.org/x/crypto/ssh`).

- Bump `golang.org/x/crypto` to v0.55.0 in every `go.mod` of this repository (including example modules).
- `go mod tidy` refreshed the transitive `golang.org/x/*` versions that v0.55.0 requires. Only `go.mod` / `go.sum` files changed.

## Related issues

- Jira: N/A
- GitHub: N/A (fixes the failing scheduled Trivy Security Scan workflow)

## AI authorship

- [ ] No AI was used
- [x] AI was used
  - **Tool / model**: Claude Code (Claude Fable 5.1)
  - **AI-authored files**: all `go.mod` / `go.sum` files in this PR (generated with `go get` + `go mod tidy`)
  - **Human line-by-line reviewed**: None — not yet reviewed by a human.

## Change classification

- [x] Leaf change
- [ ] Core change

Dependency-only bump; no source code changed.

## Plan reference

Goal: make the Trivy Security Scan workflow pass on the default branch by upgrading the vulnerable dependencies to their fixed versions. Scope: `go.mod` / `go.sum` only.

## Verification

- **Automated**:
  - `trivy fs --scanners vuln,secret,misconfig --severity CRITICAL,HIGH,MEDIUM --ignore-unfixed --exit-code 1 .` (same flags as CI, vulnerability DB dated 2026-09-05): **pass, 0 findings**
  - `go build ./...` in every module: pass
  - `go test ./...` in the root module: pass for unit tests
- **Manual**: none
- **Not run**: tests that require external services (Redis / memcached / MongoDB) were not run locally; they are covered by CI.

## Security check

- [x] No secrets in the diff
- [ ] External inputs are validated
- [ ] Permission checks are tested
- [ ] Errors do not leak internals
- [x] N/A - no external or security-sensitive interface changed

## Risk and rollback

- **Risk**: minimal; minor-version bumps of Go standard extension packages with no API changes used by this repo.
- **Rollback**: revert this commit.

## Reviewer guide

- **Read carefully**: nothing beyond the version numbers in `go.mod`.
- **Spot-check**: `go.sum` hash updates are mechanical output of `go mod tidy`.
